### PR TITLE
feat: Add conditional build rules and fix process lifecycle issues

### DIFF
--- a/cmd/godevwatch/main.go
+++ b/cmd/godevwatch/main.go
@@ -74,18 +74,18 @@ func main() {
 		}
 	}
 
-	// Enable watch mode if build/run commands are configured
-	enableWatch := config.BuildCmd != "" && config.RunCmd != ""
+	// Enable watch mode if build rules and run command are configured
+	enableWatch := len(config.BuildRules) > 0 && config.RunCmd != ""
 
 	if !enableWatch {
-		if config.BuildCmd == "" && config.RunCmd == "" {
-			log.Println("File watching disabled: build_cmd and run_cmd are not configured")
-		} else if config.BuildCmd == "" {
-			log.Println("File watching disabled: build_cmd is not configured")
+		if len(config.BuildRules) == 0 && config.RunCmd == "" {
+			log.Println("File watching disabled: build_rules and run_cmd are not configured")
+		} else if len(config.BuildRules) == 0 {
+			log.Println("File watching disabled: build_rules are not configured")
 		} else {
 			log.Println("File watching disabled: run_cmd is not configured")
 		}
-		log.Println("To enable file watching, configure both build_cmd and run_cmd in your config file")
+		log.Println("To enable file watching, configure both build_rules and run_cmd in your config file")
 	}
 
 	// Clean up any processes on the ports we're going to use

--- a/config.go
+++ b/config.go
@@ -7,16 +7,21 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// BuildRule represents a conditional build rule
+type BuildRule struct {
+	Name    string   `yaml:"name"`
+	Watch   []string `yaml:"watch"`
+	Command string   `yaml:"command"`
+}
+
 // Config represents the configuration for the dev server
 type Config struct {
-	ProxyPort      int      `yaml:"proxy_port"`
-	BackendPort    int      `yaml:"backend_port"`
-	BuildStatusDir string   `yaml:"build_status_dir"`
-	Watch          []string `yaml:"watch"`
-	WatchIgnore    []string `yaml:"watch_ignore"`
-	BuildCmd       string   `yaml:"build_cmd"`
-	RunCmd         string   `yaml:"run_cmd"`
-	InjectScript   bool     `yaml:"inject_script"`
+	ProxyPort      int         `yaml:"proxy_port"`
+	BackendPort    int         `yaml:"backend_port"`
+	BuildStatusDir string      `yaml:"build_status_dir"`
+	BuildRules     []BuildRule `yaml:"build_rules"`
+	RunCmd         string      `yaml:"run_cmd"`
+	InjectScript   bool        `yaml:"inject_script"`
 }
 
 // DefaultConfig returns a default configuration
@@ -25,11 +30,20 @@ func DefaultConfig() *Config {
 		ProxyPort:      3000,
 		BackendPort:    8080,
 		BuildStatusDir: "tmp/.build-status",
-		Watch:          []string{"**/*.go", "**/*.templ"},
-		WatchIgnore:    []string{"**/*_templ.go"},
-		BuildCmd:       "templ generate && go build -o ./tmp/main .",
-		RunCmd:         "./tmp/main",
-		InjectScript:   true,
+		BuildRules: []BuildRule{
+			{
+				Name:    "templ",
+				Watch:   []string{"**/*.templ"},
+				Command: "templ generate",
+			},
+			{
+				Name:    "go-build",
+				Watch:   []string{"**/*.go"},
+				Command: "go build -o ./tmp/main .",
+			},
+		},
+		RunCmd:       "./tmp/main",
+		InjectScript: true,
 	}
 }
 

--- a/godevwatch.example.yaml
+++ b/godevwatch.example.yaml
@@ -10,15 +10,20 @@ backend_port: 8080
 # Directory where build status files are stored
 build_status_dir: tmp/.build-status
 
-# File patterns to watch for changes
-watch:
-  - "**/*.go"
-  - "**/*.templ"
+# Build rules define conditional build steps based on file changes
+# Rules are executed in order, and only run when matching files change
+build_rules:
+  - name: "templ"
+    watch:
+      - "**/*.templ"
+    command: "templ generate"
 
-# Command to build your application
-build_cmd: "templ generate && go build -o ./tmp/main ."
+  - name: "go-build"
+    watch:
+      - "**/*.go"
+    command: "go build -o ./tmp/main ."
 
-# Command to run your application
+# Command to run your application after successful build
 run_cmd: "./tmp/main"
 
 # Whether to inject the live reload script into HTML responses

--- a/watcher.go
+++ b/watcher.go
@@ -20,7 +20,7 @@ type FileWatcher struct {
 	watcher        *fsnotify.Watcher
 	mu             sync.Mutex
 	debounceTime   time.Duration
-	buildTrigger   chan bool
+	buildTrigger   chan []string // Changed files that triggered the build
 	currentBuild   *Command
 	stopChan       chan bool
 }
@@ -40,7 +40,7 @@ func NewFileWatcher(config *Config, buildTracker *BuildTracker) (*FileWatcher, e
 		processManager: processManager,
 		watcher:        watcher,
 		debounceTime:   100 * time.Millisecond,
-		buildTrigger:   make(chan bool, 1), // Non-blocking trigger
+		buildTrigger:   make(chan []string, 1), // Non-blocking trigger with changed files
 		stopChan:       make(chan bool),
 	}, nil
 }
@@ -58,8 +58,8 @@ func (fw *FileWatcher) Start() error {
 	// Start file event processor
 	go fw.processFileEvents()
 
-	// Trigger initial build
-	fw.triggerBuild()
+	// Trigger initial build with all rules
+	fw.triggerBuild(nil)
 
 	return nil
 }
@@ -95,6 +95,8 @@ func (fw *FileWatcher) addWatchPaths() error {
 // processFileEvents processes file system events
 func (fw *FileWatcher) processFileEvents() {
 	var debounceTimer *time.Timer
+	var changedFiles []string
+	var filesMu sync.Mutex
 
 	for {
 		select {
@@ -103,10 +105,15 @@ func (fw *FileWatcher) processFileEvents() {
 				return
 			}
 
-			// Check if file matches watch patterns
+			// Check if file matches any watch pattern in build rules
 			if !fw.shouldWatch(event.Name) {
 				continue
 			}
+
+			// Track changed file
+			filesMu.Lock()
+			changedFiles = append(changedFiles, event.Name)
+			filesMu.Unlock()
 
 			// Debounce rapid file changes
 			if debounceTimer != nil {
@@ -114,7 +121,13 @@ func (fw *FileWatcher) processFileEvents() {
 			}
 
 			debounceTimer = time.AfterFunc(fw.debounceTime, func() {
-				fw.triggerBuild()
+				filesMu.Lock()
+				files := make([]string, len(changedFiles))
+				copy(files, changedFiles)
+				changedFiles = nil
+				filesMu.Unlock()
+
+				fw.triggerBuild(files)
 			})
 
 		case err, ok := <-fw.watcher.Errors:
@@ -129,37 +142,11 @@ func (fw *FileWatcher) processFileEvents() {
 	}
 }
 
-// shouldWatch checks if a file matches the watch patterns
+// shouldWatch checks if a file matches any watch pattern in build rules
 func (fw *FileWatcher) shouldWatch(path string) bool {
-	// First check if file should be ignored
-	for _, pattern := range fw.config.WatchIgnore {
-		// Simple glob matching
-		matched, err := filepath.Match(pattern, filepath.Base(path))
-		if err == nil && matched {
-			return false
-		}
-
-		// Check extension-based matching (e.g., **/*_templ.go)
-		if strings.Contains(pattern, "**/*") {
-			suffix := strings.TrimPrefix(pattern, "**/*")
-			if strings.HasSuffix(path, suffix) {
-				return false
-			}
-		}
-	}
-
-	// Then check if file matches watch patterns
-	for _, pattern := range fw.config.Watch {
-		// Simple glob matching
-		matched, err := filepath.Match(pattern, filepath.Base(path))
-		if err == nil && matched {
-			return true
-		}
-
-		// Check extension-based matching (e.g., **/*.go)
-		if strings.Contains(pattern, "**/*") {
-			ext := strings.TrimPrefix(pattern, "**/*")
-			if strings.HasSuffix(path, ext) {
+	for _, rule := range fw.config.BuildRules {
+		for _, pattern := range rule.Watch {
+			if fw.matchesPattern(path, pattern) {
 				return true
 			}
 		}
@@ -167,10 +154,29 @@ func (fw *FileWatcher) shouldWatch(path string) bool {
 	return false
 }
 
+// matchesPattern checks if a file matches a watch pattern
+func (fw *FileWatcher) matchesPattern(path, pattern string) bool {
+	// Simple glob matching
+	matched, err := filepath.Match(pattern, filepath.Base(path))
+	if err == nil && matched {
+		return true
+	}
+
+	// Check extension-based matching (e.g., **/*.go)
+	if strings.Contains(pattern, "**/*") {
+		ext := strings.TrimPrefix(pattern, "**/*")
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // triggerBuild triggers a build, aborting current one if running
-func (fw *FileWatcher) triggerBuild() {
+func (fw *FileWatcher) triggerBuild(changedFiles []string) {
 	select {
-	case fw.buildTrigger <- true:
+	case fw.buildTrigger <- changedFiles:
 		// Build triggered successfully
 	default:
 		// Build already pending, skip
@@ -181,18 +187,25 @@ func (fw *FileWatcher) triggerBuild() {
 func (fw *FileWatcher) processBuildTriggers() {
 	for {
 		select {
-		case <-fw.buildTrigger:
-			// Abort current build if running
+		case changedFiles := <-fw.buildTrigger:
+			// If there's a current build command running, abort it
 			fw.mu.Lock()
 			if fw.currentBuild != nil {
 				log.Println("\033[33mAborting current build due to file change...\033[0m")
+
+				// Mark current build as aborted first
+				currentBuildID, _ := fw.buildTracker.GetCurrentBuildID()
+				if currentBuildID != "" {
+					fw.buildTracker.SetStatus(currentBuildID, BuildStatusAborted)
+				}
+
 				fw.currentBuild.Kill()
 				fw.currentBuild = nil
 			}
 			fw.mu.Unlock()
 
-			// Execute new build
-			fw.executeBuild()
+			// Execute new build with changed files
+			fw.executeBuild(changedFiles)
 
 		case <-fw.stopChan:
 			return
@@ -200,8 +213,18 @@ func (fw *FileWatcher) processBuildTriggers() {
 	}
 }
 
-// executeBuild executes the build and run commands
-func (fw *FileWatcher) executeBuild() {
+// executeBuild executes the build rules based on changed files
+func (fw *FileWatcher) executeBuild(changedFiles []string) {
+	// Step 1: Stop the running application FIRST (before creating new build)
+	// This ensures the port is freed before we try to start the new build
+	if changedFiles != nil { // Only stop if this is a rebuild (not initial build)
+		tempBuildID := "stopping"
+		if err := fw.processManager.StopCurrentProcess(tempBuildID); err != nil {
+			log.Printf("Failed to stop previous process: %v", err)
+		}
+	}
+
+	// Step 2: Create new build ID and set it as current with "building" status
 	buildID, err := fw.buildTracker.NewBuild()
 	if err != nil {
 		log.Printf("Failed to create build ID: %v", err)
@@ -210,63 +233,71 @@ func (fw *FileWatcher) executeBuild() {
 
 	log.Printf("\n\033[36m[%s] Starting build...\033[0m\n", buildID)
 
-	// Stop any running process before building
-	if err := fw.processManager.StartBuild(buildID); err != nil {
-		log.Printf("Failed to stop previous process: %v", err)
-	}
-
 	// Set building status
 	if err := fw.buildTracker.SetStatus(buildID, BuildStatusBuilding); err != nil {
 		log.Printf("Failed to set build status: %v", err)
 		return
 	}
 
-	// Parse and execute build command
-	buildCmd := NewCommand(fw.config.BuildCmd)
-	buildCmd.OnStdout = func(line string) {
-		fmt.Println(line)
-	}
-	buildCmd.OnStderr = func(line string) {
-		fmt.Fprintln(os.Stderr, line)
-	}
+	// Step 3: Determine which build rules to run
+	rulesToRun := fw.determineRulesToRun(changedFiles)
 
-	// Track current build so it can be aborted
-	fw.mu.Lock()
-	fw.currentBuild = buildCmd
-	fw.mu.Unlock()
-
-	if err := buildCmd.Run(); err != nil {
-		// Check if it was aborted vs actual failure
-		fw.mu.Lock()
-		wasAborted := fw.currentBuild == nil
-		fw.mu.Unlock()
-
-		if wasAborted {
-			log.Printf("\033[33m[%s] Build aborted\033[0m\n", buildID)
-			fw.buildTracker.SetStatus(buildID, BuildStatusAborted)
-		} else {
-			log.Printf("\033[31m[%s] Build failed: %v\033[0m\n", buildID, err)
-			fw.buildTracker.SetStatus(buildID, BuildStatusFailed)
-		}
-
-		fw.mu.Lock()
-		fw.currentBuild = nil
-		fw.mu.Unlock()
+	if len(rulesToRun) == 0 {
+		log.Printf("\033[33m[%s] No matching build rules found\033[0m\n", buildID)
+		fw.buildTracker.ClearBuild(buildID)
 		return
 	}
 
-	// Clear current build tracking
-	fw.mu.Lock()
-	fw.currentBuild = nil
-	fw.mu.Unlock()
+	// Step 4: Execute each matching build rule in order
+	for _, rule := range rulesToRun {
+		log.Printf("\033[36m[%s] Running rule: %s\033[0m\n", buildID, rule.Name)
 
-	// Build succeeded, clean up status files
+		buildCmd := NewCommand(rule.Command)
+		buildCmd.OnStdout = func(line string) {
+			fmt.Println(line)
+		}
+		buildCmd.OnStderr = func(line string) {
+			fmt.Fprintln(os.Stderr, line)
+		}
+
+		// Track current build so it can be aborted
+		fw.mu.Lock()
+		fw.currentBuild = buildCmd
+		fw.mu.Unlock()
+
+		if err := buildCmd.Run(); err != nil {
+			// Check if it was aborted vs actual failure
+			fw.mu.Lock()
+			wasAborted := fw.currentBuild == nil
+			fw.mu.Unlock()
+
+			if wasAborted {
+				log.Printf("\033[33m[%s] Build aborted\033[0m\n", buildID)
+				fw.buildTracker.SetStatus(buildID, BuildStatusAborted)
+			} else {
+				log.Printf("\033[31m[%s] Build failed: %v\033[0m\n", buildID, err)
+				fw.buildTracker.SetStatus(buildID, BuildStatusFailed)
+			}
+
+			fw.mu.Lock()
+			fw.currentBuild = nil
+			fw.mu.Unlock()
+			return
+		}
+
+		// Clear current build tracking after each rule
+		fw.mu.Lock()
+		fw.currentBuild = nil
+		fw.mu.Unlock()
+	}
+
+	// Step 5: Build succeeded - clean up status files
 	fw.buildTracker.CleanupOldFailed(buildID)
 	fw.buildTracker.ClearBuild(buildID)
 
 	log.Printf("\033[32m[%s] Build succeeded\033[0m\n", buildID)
 
-	// Run the application
+	// Step 6: Run the application (port should be free now)
 	if fw.config.RunCmd != "" {
 		if err := fw.processManager.RunProcess(buildID); err != nil {
 			log.Printf("Failed to start application: %v", err)
@@ -274,6 +305,38 @@ func (fw *FileWatcher) executeBuild() {
 			log.Printf("\033[32m[%s] Application started\033[0m\n", buildID)
 		}
 	}
+}
+
+// determineRulesToRun determines which build rules should run based on changed files
+func (fw *FileWatcher) determineRulesToRun(changedFiles []string) []BuildRule {
+	// If no specific files changed (initial build), run all rules
+	if len(changedFiles) == 0 {
+		return fw.config.BuildRules
+	}
+
+	// Track which rules need to run
+	ruleMatches := make(map[int]bool)
+
+	for _, file := range changedFiles {
+		for i, rule := range fw.config.BuildRules {
+			for _, pattern := range rule.Watch {
+				if fw.matchesPattern(file, pattern) {
+					ruleMatches[i] = true
+					break
+				}
+			}
+		}
+	}
+
+	// Build list of rules to run in order
+	var rulesToRun []BuildRule
+	for i, rule := range fw.config.BuildRules {
+		if ruleMatches[i] {
+			rulesToRun = append(rulesToRun, rule)
+		}
+	}
+
+	return rulesToRun
 }
 
 // Stop stops the file watcher


### PR DESCRIPTION
This commit implements conditional build rules and resolves critical process management issues that caused "address already in use" errors during rebuilds.

## Major Changes

### 1. Conditional Build Rules (config.go, godevwatch.example.yaml)
- Replaced single `build_cmd` with `build_rules` array structure
- Each rule specifies: name, watch patterns, and command
- Enables conditional execution based on file changes
- Example: Run `templ generate` only when .templ files change, run `go build` only when .go files change

### 2. Intelligent Build Execution (watcher.go)
- Added `determineRulesToRun()` to match changed files to build rules
- Only executes relevant build rules on file changes
- Runs all rules in order during initial build
- Tracks changed files during debounce period
- Properly marks builds as "aborted" when interrupted

### 3. Process Lifecycle Fixes (command.go, process_manager.go)
- Fixed critical issue where processes weren't fully terminated before restart
- `Command.Kill()` now waits up to 2s for graceful termination
- Falls back to SIGKILL if SIGTERM doesn't work
- Renamed `StartBuild()` to `StopCurrentProcess()` for clarity
- **Critical**: Application now stops BEFORE new build starts, preventing "bind: address already in use" errors

### 4. Build Tracking Enhancements (build_tracker.go)
- Added `current-build-id` file to track active build
- New `GetCurrentBuildID()` method for status queries
- Enables proper abort tracking during file changes

## Build Sequence

**Initial Startup:**
1. Clean ports (proxy & backend)
2. Create build status directory
3. Create build with "building" status + current-build-id file
4. Start file watcher
5. Start proxy server (shows "building" status)
6. Execute build rules
7. Clear "building" status on success
8. Start application
9. Browser auto-reloads

**On File Change:**
1. Mark current build as "aborted" (if building)
2. **Stop running application and wait for termination**
3. Create new build with "building" status + current-build-id
4. Execute matching build rules only
5. Clear "building" status on success
6. Start application (port now free!)
7. Browser auto-reloads

## Breaking Changes

- Config structure changed from `build_cmd` to `build_rules`
- Removed `watch` and `watch_ignore` top-level fields
- Watch patterns now defined per build rule

## Benefits

- 🚀 Faster rebuilds (only runs necessary build steps)
- 🔧 No more "address already in use" errors
- 📊 Better build status tracking
- 🎯 More flexible build configurations
- ⚡ Proper process cleanup and lifecycle management

🤖 Generated with [Claude Code](https://claude.com/claude-code)